### PR TITLE
prepare release io.esastack:commons

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,6 +39,7 @@ jobs:
       if: github.event.inputs.profiles != ''
       run: mvn -P ${{ github.event.inputs.profiles }} clean package
     - name: Upload coverage to Codecov
+      if: github.event_name == 'push'
       uses: codecov/codecov-action@v1.0.2
       with:
           token: ${{secrets.CODECOV_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build](https://github.com/esastack/esa-commons/workflows/Build/badge.svg?branch=main)
 [![codecov](https://codecov.io/gh/esastack/esa-commons/branch/main/graph/badge.svg?token=HUHT6S30PD)](https://codecov.io/gh/esastack/esa-commons)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.esastack/commons/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.esastack/commons/)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.esastack/commons/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.esastack/commons/)
 [![GitHub license](https://img.shields.io/github/license/esastack/esa-commons)](https://github.com/esastack/esa-commons/blob/main/LICENSE)
 
 
@@ -23,7 +23,7 @@ ESA Commons is the common lib of `ESA Stack`.
 
 ```xml
 <dependency>
-    <groupId>com.github.esastack</groupId>
+    <groupId>io.esastack</groupId>
     <artifactId>commons</artifactId>
     <version>${esa-httpserver.version}</version>
 </dependency>
@@ -277,11 +277,11 @@ add spec file to `META-INF/services/`, or `META-INF/esa/`, or  `META-INF/esa/int
 
 so we add a spec file
 
-> META-INF/services/com.github.esastack.commons.Shape
+> META-INF/services/io.esastack.commons.Shape
 >
 > ```
-> com.github.esastack.commons.Circle
-> com.github.esastack.commons.Triangle
+> io.esastack.commons.Circle
+> io.esastack.commons.Triangle
 > ```
 
 use `SpiLoader` to get SPI extensions

--- a/commons-benchmarks/pom.xml
+++ b/commons-benchmarks/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.esastack</groupId>
+        <groupId>io.esastack</groupId>
         <artifactId>commons-parent</artifactId>
         <version>0.0.2-SNAPSHOT</version>
     </parent>

--- a/commons-benchmarks/pom.xml
+++ b/commons-benchmarks/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.esastack</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>commons-benchmarks</artifactId>
     <name>Commons :: Benchmarks</name>

--- a/commons-build/pom.xml
+++ b/commons-build/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>io.esastack</groupId>
     <artifactId>commons-build</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
 
     <name>Commons :: build</name>
     <description>

--- a/commons-build/pom.xml
+++ b/commons-build/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.esastack</groupId>
+    <groupId>io.esastack</groupId>
     <artifactId>commons-build</artifactId>
     <version>0.0.2-SNAPSHOT</version>
 

--- a/commons-concurrency-test/pom.xml
+++ b/commons-concurrency-test/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.esastack</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>commons-concurrency-test</artifactId>
     <name>Commons :: ConcurrencyTest</name>

--- a/commons-concurrency-test/pom.xml
+++ b/commons-concurrency-test/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.esastack</groupId>
+        <groupId>io.esastack</groupId>
         <artifactId>commons-parent</artifactId>
         <version>0.0.2-SNAPSHOT</version>
     </parent>

--- a/commons-http/pom.xml
+++ b/commons-http/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.esastack</groupId>
+        <groupId>io.esastack</groupId>
         <artifactId>commons-parent</artifactId>
         <version>0.0.2-SNAPSHOT</version>
     </parent>

--- a/commons-http/pom.xml
+++ b/commons-http/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.esastack</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>commons-http</artifactId>

--- a/commons-netty/commons-netty-core/pom.xml
+++ b/commons-netty/commons-netty-core/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.esastack</groupId>
+        <groupId>io.esastack</groupId>
         <artifactId>commons-netty</artifactId>
         <version>0.0.2-SNAPSHOT</version>
     </parent>

--- a/commons-netty/commons-netty-core/pom.xml
+++ b/commons-netty/commons-netty-core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.esastack</groupId>
         <artifactId>commons-netty</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>commons-netty-core</artifactId>

--- a/commons-netty/commons-netty-http/pom.xml
+++ b/commons-netty/commons-netty-http/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.esastack</groupId>
         <artifactId>commons-netty</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>commons-netty-http</artifactId>

--- a/commons-netty/commons-netty-http/pom.xml
+++ b/commons-netty/commons-netty-http/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.esastack</groupId>
+        <groupId>io.esastack</groupId>
         <artifactId>commons-netty</artifactId>
         <version>0.0.2-SNAPSHOT</version>
     </parent>

--- a/commons-netty/pom.xml
+++ b/commons-netty/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.esastack</groupId>
+        <groupId>io.esastack</groupId>
         <artifactId>commons-parent</artifactId>
         <version>0.0.2-SNAPSHOT</version>
     </parent>

--- a/commons-netty/pom.xml
+++ b/commons-netty/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.esastack</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>commons-netty</artifactId>
     <packaging>pom</packaging>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github.esastack</groupId>
+        <groupId>io.esastack</groupId>
         <artifactId>commons-parent</artifactId>
         <version>0.0.2-SNAPSHOT</version>
     </parent>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.esastack</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>commons</artifactId>
     <name>Commons :: Core</name>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.esastack</groupId>
+    <groupId>io.esastack</groupId>
     <artifactId>commons-parent</artifactId>
     <packaging>pom</packaging>
     <version>0.0.2-SNAPSHOT</version>
@@ -68,6 +68,16 @@
                             </execution>
                         </executions>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>export-javadoc</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
@@ -155,7 +165,7 @@
                             <configuration>
                                 <skip>false</skip>
                                 <configLocation>esa/commons/checkstyle.xml</configLocation>
-                                <encoding>UTF-8</encoding>
+                                <encoding>${encoding}</encoding>
                                 <consoleOutput>true</consoleOutput>
                                 <logViolationsToConsole>true</logViolationsToConsole>
                                 <failsOnError>true</failsOnError>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <groupId>io.esastack</groupId>
     <artifactId>commons-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
 
     <name>Commons</name>
     <description>


### PR DESCRIPTION
1. Change group id to io.esastack
2. rollback version to 0.0.1-SNAPSHOT(for releasing v0.0.1)