### PR TITLE
spi force include and exclude operations are supported for function named getByFeatures

### DIFF
--- a/commons/src/main/java/esa/commons/spi/SpiLoader.java
+++ b/commons/src/main/java/esa/commons/spi/SpiLoader.java
@@ -11,7 +11,16 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -332,8 +341,8 @@ public class SpiLoader<T> {
      * <p>- Match the input parameters with @{@link Feature} annotation's fields.</p>
      * <p>- Selectively get the extensions whose "groups" or "tags" of @{@link Feature} is not configured.</p>
      *
-     * @param namesFilter         when group is match, names started with prefix "-" in namesFilter will be force
-     *                            removed from while others will be force added into the result list.
+     * @param namesFilter         when group is matched, names started with prefix "-" in namesFilter will be forcibly
+     *                            removed while others will be forcibly added into the result list.
      * @param group               expected group name of extension, match with the "groups" of @{@link Feature}
      * @param tags                expected key-values of extension, match with the "tags" of @{@link Feature}
      * @param matchGroupIfMissing whether return the extensions whose @{@link Feature} "groups" is not configured

--- a/commons/src/test/java/esa/commons/spi/extensionloader/AllTypeGetExtensionFunctionTest.java
+++ b/commons/src/test/java/esa/commons/spi/extensionloader/AllTypeGetExtensionFunctionTest.java
@@ -22,16 +22,20 @@ import esa.commons.spi.extensionloader.emptyparams.Impl1;
 import esa.commons.spi.extensionloader.emptyparams.Impl2;
 import esa.commons.spi.extensionloader.emptyparams.Impl3;
 import esa.commons.spi.extensionloader.emptyparams.TestEmptySpi;
+import esa.commons.spi.extensionloader.forcespecify.*;
 import esa.commons.spi.extensionloader.wrapper.TestWrapperSpi;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class AllTypeGetExtensionFunctionTest {
 
@@ -198,5 +202,29 @@ class AllTypeGetExtensionFunctionTest {
 
         assertThrows(Exception.class, () -> loader.getByFeature("TEST", tags));
         assertEquals(2, loader.getByFeature("TEST", tags, true).size());
+    }
+
+    @Test
+    void testForceSpecify() {
+        final Set<String> namesFilter = new HashSet<>();
+        namesFilter.add("impl1");
+        namesFilter.add("-impl2");
+        namesFilter.add("impl4");
+        final Map<String, String> tags = new HashMap<>();
+        tags.put("k1", "v1");
+
+        final SpiLoader<TestForceSpecify> loader = SpiLoader.cached(TestForceSpecify.class);
+        List<TestForceSpecify> testForceSpecifies = loader.getByFeature(namesFilter, "group1", false,
+                tags, false, false);
+        assertEquals(2, testForceSpecifies.size());
+
+        final Set<String> clzNamesLoaded = new HashSet<>();
+        for (TestForceSpecify forceSpecify : testForceSpecifies) {
+            clzNamesLoaded.add(forceSpecify.getClass().getName());
+        }
+        assertTrue(clzNamesLoaded.contains(TestForceSpecifyImpl1.class.getName()));
+        assertFalse(clzNamesLoaded.contains(TestForceSpecifyImpl2.class.getName()));
+        assertTrue(clzNamesLoaded.contains(TestForceSpecifyImpl3.class.getName()));
+        assertFalse(clzNamesLoaded.contains(TestForceSpecifyImpl4.class.getName()));
     }
 }

--- a/commons/src/test/java/esa/commons/spi/extensionloader/forcespecify/TestForceSpecify.java
+++ b/commons/src/test/java/esa/commons/spi/extensionloader/forcespecify/TestForceSpecify.java
@@ -1,0 +1,7 @@
+package esa.commons.spi.extensionloader.forcespecify;
+
+import esa.commons.spi.SPI;
+
+@SPI
+public interface TestForceSpecify {
+}

--- a/commons/src/test/java/esa/commons/spi/extensionloader/forcespecify/TestForceSpecifyImpl1.java
+++ b/commons/src/test/java/esa/commons/spi/extensionloader/forcespecify/TestForceSpecifyImpl1.java
@@ -1,0 +1,7 @@
+package esa.commons.spi.extensionloader.forcespecify;
+
+import esa.commons.spi.Feature;
+
+@Feature(groups = {"group1"}, tags = {"k1:v2"})
+public class TestForceSpecifyImpl1 implements TestForceSpecify {
+}

--- a/commons/src/test/java/esa/commons/spi/extensionloader/forcespecify/TestForceSpecifyImpl2.java
+++ b/commons/src/test/java/esa/commons/spi/extensionloader/forcespecify/TestForceSpecifyImpl2.java
@@ -1,0 +1,7 @@
+package esa.commons.spi.extensionloader.forcespecify;
+
+import esa.commons.spi.Feature;
+
+@Feature(groups = {"group1"}, tags = {"k1:v1"})
+public class TestForceSpecifyImpl2 implements TestForceSpecify {
+}

--- a/commons/src/test/java/esa/commons/spi/extensionloader/forcespecify/TestForceSpecifyImpl3.java
+++ b/commons/src/test/java/esa/commons/spi/extensionloader/forcespecify/TestForceSpecifyImpl3.java
@@ -1,0 +1,7 @@
+package esa.commons.spi.extensionloader.forcespecify;
+
+import esa.commons.spi.Feature;
+
+@Feature(groups = {"group1"}, tags = {"k1:v1"})
+public class TestForceSpecifyImpl3 implements TestForceSpecify {
+}

--- a/commons/src/test/java/esa/commons/spi/extensionloader/forcespecify/TestForceSpecifyImpl4.java
+++ b/commons/src/test/java/esa/commons/spi/extensionloader/forcespecify/TestForceSpecifyImpl4.java
@@ -1,0 +1,7 @@
+package esa.commons.spi.extensionloader.forcespecify;
+
+import esa.commons.spi.Feature;
+
+@Feature(groups = {"group2"}, tags = {"k1:v1"})
+public class TestForceSpecifyImpl4 implements TestForceSpecify {
+}

--- a/commons/src/test/resources/META-INF/esa/esa.commons.spi.extensionloader.forcespecify.TestForceSpecify
+++ b/commons/src/test/resources/META-INF/esa/esa.commons.spi.extensionloader.forcespecify.TestForceSpecify
@@ -1,0 +1,4 @@
+impl1=esa.commons.spi.extensionloader.forcespecify.TestForceSpecifyImpl1
+impl2=esa.commons.spi.extensionloader.forcespecify.TestForceSpecifyImpl2
+impl3=esa.commons.spi.extensionloader.forcespecify.TestForceSpecifyImpl3
+impl4=esa.commons.spi.extensionloader.forcespecify.TestForceSpecifyImpl4


### PR DESCRIPTION
1. Parameter named forceExcludeNames is supported for function getByFeatures