### PR TITLE
fix 408 http code cannot be retried

### DIFF
--- a/commons/src/main/java/esa/commons/SimpleHttpUtils.java
+++ b/commons/src/main/java/esa/commons/SimpleHttpUtils.java
@@ -83,9 +83,9 @@ public final class SimpleHttpUtils {
             IOUtils.closeQuietly(outputStream);
 
             int respCode = urlConnection.getResponseCode();
-            inputStream = urlConnection.getInputStream();
 
             if (200 == respCode) {
+                inputStream = urlConnection.getInputStream();
                 return IOUtils.toByteArray(inputStream);
             } else if (408 == respCode) {
                 failUrls.add(url);


### PR DESCRIPTION
urlConnection.getInputStream() will throw IO exception when 408 http status